### PR TITLE
Correction: Compute Engine SA is used for Cloud functions, not App En…

### DIFF
--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-functions-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-functions-enum.md
@@ -30,7 +30,7 @@ gcp-artifact-registry-enum.md
 
 ### SA
 
-If not specified, by default the **App Engine Default Service Account** with **Editor permissions** over the project will be attached to the Cloud Function.
+If not specified, by default the **Compute Engine Default Service Account** with **Editor permissions** over the project will be attached to the Cloud Function.
 
 ### Triggers, URL & Authentication
 


### PR DESCRIPTION
…gine SA

see https://cloud.google.com/run/docs/securing/security#what_your_service_or_job_can_access





